### PR TITLE
Use activesupport not active_support

### DIFF
--- a/guideline.gemspec
+++ b/guideline.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "slop"
   gem.add_dependency "code_analyzer"
-  gem.add_dependency "active_support"
+  gem.add_dependency "activesupport"
   gem.add_development_dependency "rspec", ">=2.12.0"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "simplecov"


### PR DESCRIPTION
`gem install active_support` brings `active_support v3.0.0` and `activesupport v3.0.0` .
This is not intended, I think.
