### PR TITLE
Guidline::Visitor#render sort by line

### DIFF
--- a/lib/guideline/visitor.rb
+++ b/lib/guideline/visitor.rb
@@ -28,7 +28,7 @@ module Guideline
     def render
       errors.group_by(&:path).each do |path, errors|
         puts path
-        errors.each(&:render)
+        errors.sort_by(&:line).each(&:render)
         puts
       end
     end

--- a/spec/guideline/visitor_spec.rb
+++ b/spec/guideline/visitor_spec.rb
@@ -88,7 +88,7 @@ module Guideline
       end
 
       let(:error) do
-        mock(:path => "path")
+        mock(:path => "path", :line => 1)
       end
 
       it "calls #render of each error" do


### PR DESCRIPTION
Add sorting by line number into error renderer.
This change `guideline` results from:

```
api/kindle_comic.rb
  12: ABC Complexity of method<#main> 16 should be less than 10
  12: Remove unused method <main>
  30: Remove unused method <default_params>
  36: There should be a comma after the last value of Hash
  13: Line length 104 should be less than  80 characters
  12: Too long  15 lines method <#main>
```

to:

```
api/kindle_comic.rb
  12: ABC Complexity of method<#main> 16 should be less than 10
  12: Remove unused method <main>
  12: Too long  15 lines method <#main>
  13: Line length 104 should be less than  80 characters
  30: Remove unused method <default_params>
  36: There should be a comma after the last value of Hash
```
