### PR TITLE
Ripper lexes :on_embexpr_end from :on_rbrace on ruby2.0.0-preview1

### DIFF
--- a/lib/guideline/checkers/hash_comma_checker.rb
+++ b/lib/guideline/checkers/hash_comma_checker.rb
@@ -32,6 +32,11 @@ module Guideline
         push_stacks
       end
 
+      def on_embexpr_end(token)
+        call(lineno) if has_error?
+        pop_stacks
+      end
+
       def on_rbrace(token)
         call(lineno) if has_error?
         pop_stacks


### PR DESCRIPTION
2.0.0でembedded expansionの場合の`}`のRipperの挙動が変わってた
on_rbraceをコピペしたけど、この直し方でよかったのかはわかってない

Diff between 1.9.3-p327 and 2.0.0-preview1

```
Ripper.lex("            {\n              :a => \"\#{b(1, 2)}\"\n            }\n")
-  [[2, 30], :on_rbrace, "}"],
+  [[2, 30], :on_embexpr_end, "}"],
```

```
#1.9.3-p327
Ripper.lex("            {\n              :a => \"\#{b(1, 2)}\"\n            }\n")
=> [[[1, 0], :on_sp, "            "],
 [[1, 12], :on_lbrace, "{"],
 [[1, 13], :on_ignored_nl, "\n"],
 [[2, 0], :on_sp, "              "],
 [[2, 14], :on_symbeg, ":"],
 [[2, 15], :on_ident, "a"],
 [[2, 16], :on_sp, " "],
 [[2, 17], :on_op, "=>"],
 [[2, 19], :on_sp, " "],
 [[2, 20], :on_tstring_beg, "\""],
 [[2, 21], :on_embexpr_beg, "\#{"],
 [[2, 23], :on_ident, "b"],
 [[2, 24], :on_lparen, "("],
 [[2, 25], :on_int, "1"],
 [[2, 26], :on_comma, ","],
 [[2, 27], :on_sp, " "],
 [[2, 28], :on_int, "2"],
 [[2, 29], :on_rparen, ")"],
 [[2, 30], :on_rbrace, "}"],
 [[2, 31], :on_tstring_end, "\""],
 [[2, 32], :on_nl, "\n"],
 [[3, 0], :on_sp, "            "],
 [[3, 12], :on_rbrace, "}"],
 [[3, 13], :on_nl, "\n"]]
```

```
#2.0.0-preview1
Ripper.lex("            {\n              :a => \"\#{b(1, 2)}\"\n            }\n")
=> [[[1, 0], :on_sp, "            "],
 [[1, 12], :on_lbrace, "{"],
 [[1, 13], :on_ignored_nl, "\n"],
 [[2, 0], :on_sp, "              "],
 [[2, 14], :on_symbeg, ":"],
 [[2, 15], :on_ident, "a"],
 [[2, 16], :on_sp, " "],
 [[2, 17], :on_op, "=>"],
 [[2, 19], :on_sp, " "],
 [[2, 20], :on_tstring_beg, "\""],
 [[2, 21], :on_embexpr_beg, "\#{"],
 [[2, 23], :on_ident, "b"],
 [[2, 24], :on_lparen, "("],
 [[2, 25], :on_int, "1"],
 [[2, 26], :on_comma, ","],
 [[2, 27], :on_sp, " "],
 [[2, 28], :on_int, "2"],
 [[2, 29], :on_rparen, ")"],
 [[2, 30], :on_embexpr_end, "}"],
 [[2, 31], :on_tstring_end, "\""],
 [[2, 32], :on_nl, "\n"],
 [[3, 0], :on_sp, "            "],
 [[3, 12], :on_rbrace, "}"],
 [[3, 13], :on_nl, "\n"]]
```

関連するのこれかな?
Bug #6211: Ripper lexes :on_rbrace when it should find :on_embexpr_end -
ruby-trunk - Ruby Issue Tracking System
http://bugs.ruby-lang.org/issues/6211
