### PR TITLE
Put an end to YAML option and provide command-line options

### DIFF
--- a/.guideline.yml
+++ b/.guideline.yml
@@ -1,6 +1,0 @@
-"Guideline::LongLineChecker":
-  max: 80
-"Guideline::LongMethodChecker":
-  max: 10
-"Guideline::AbcComplexityChecker":
-  max: 10

--- a/README.md
+++ b/README.md
@@ -20,15 +20,22 @@ $ gem install guideline
 ## Usage
 ```
 $ guideline --help
-Usage: guideline [directory] [options]
-    -c, --config       Path to config YAML file.
-    -i, --init         Generate config YAML template into current directory.
-    -v, --version      Show version number.
-    -h, --help         Display this help message.
+Usage: guideline [options]
+        --no-abc-complexity          (default: true) check method ABC complexity
+        --no-hard-tab-indent         (default: true) check hard tab indent
+        --no-hash-comma              (default: true) check last comma in Hash literal
+        --no-long-line               (default: true) check line length
+        --no-long-method             (default: true) check method height
+        --no-trailing-whitespace     (default: true) check trailing whitespace
+        --no-unused-method           (default: true) check unused method
+        --abc-complexity=            (default:   15) threshold of ABC complexity
+        --long-line=                 (default:   80) threshold of long line
+        --long-method=               (default:   10) threshold of long method
+        --path=                      (default:   ./) checked file or dir or glob pattern
 ```
 
 ```
-$ guideline ./chatroid
+$ guideline --path /path/to/chatroid
 
 lib/chatroid/adapter/campfire.rb
   26: Line length  85 should be less than  80 characters
@@ -47,7 +54,7 @@ lib/chatroid/adapter/twitter.rb
 ```
 
 ```
-$ guideline ./guideline
+$ guideline --path /path/to/guideline
 
 lib/guideline/checkers/abc_complexity_checker.rb
   40: ABC Complexity of method<Guideline::AbcComplexityChecker::Moduleable.included> 16 should be less than 10

--- a/bin/guideline
+++ b/bin/guideline
@@ -2,22 +2,5 @@
 
 $LOAD_PATH.unshift File.expand_path("../../lib/", __FILE__)
 require "guideline"
-include Guideline
 
-options = Runner.parse(ARGV)
-
-checkers = CheckerFactory.new(
-  options[:config],
-  AbcComplexityChecker,
-  HardTabIndentChecker,
-  HashCommaChecker,
-  LongLineChecker,
-  LongMethodChecker,
-  TrailingWhitespaceChecker,
-  UnusedMethodChecker,
-).create
-
-visitor = Visitor.new(:only => ARGV[0], :checker => checkers)
-visitor.prepare
-visitor.visit
-visitor.render
+Guideline::Runner.run

--- a/guideline.gemspec
+++ b/guideline.gemspec
@@ -18,9 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "slop"
   gem.add_dependency "code_analyzer"
-  gem.add_dependency "activesupport"
   gem.add_development_dependency "rspec", ">=2.12.0"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "simplecov"

--- a/lib/guideline.rb
+++ b/lib/guideline.rb
@@ -1,6 +1,8 @@
 require "guideline/version"
+require "guideline/path_finder"
 require "guideline/visitor"
 require "guideline/error"
+require "guideline/option_parser"
 require "guideline/runner"
 require "guideline/parser/moduleable"
 require "guideline/checker_factory"

--- a/lib/guideline/checkers/abc_complexity_checker.rb
+++ b/lib/guideline/checkers/abc_complexity_checker.rb
@@ -12,22 +12,18 @@ module Guideline
 
     def checker
       AbcParser.new do |complexity, method, module_name, class_method_flag|
-        begin
-          if complexity > max
-            report(
-              :path    => @current_path,
-              :line    => method.line,
-              :message => "ABC Complexity of method<%s%s%s>%3d should be less than %d" % [
-                module_name,
-                class_method_flag ? "." : "#",
-                method.method_name,
-                complexity,
-                max,
-              ]
-            )
-          end
-        rescue Exception
-          require "pry"; binding.pry
+        if complexity > max
+          report(
+            :path    => @current_path,
+            :line    => method.line,
+            :message => "ABC Complexity of method<%s%s%s>%3d should be less than %d" % [
+              module_name,
+              class_method_flag ? "." : "#",
+              method.method_name,
+              complexity,
+              max,
+            ]
+          )
         end
       end
     end

--- a/lib/guideline/checkers/abc_complexity_checker.rb
+++ b/lib/guideline/checkers/abc_complexity_checker.rb
@@ -2,6 +2,8 @@ require "code_analyzer"
 
 module Guideline
   class AbcComplexityChecker < Checker
+    DEFAULT_MAX = 15
+
     def check(path)
       @current_path = path
       visitor.check(path.to_s, path.read)
@@ -33,7 +35,7 @@ module Guideline
     end
 
     def max
-      @options[:max]
+      (@options[:max] || DEFAULT_MAX).to_i
     end
 
     class AbcParser <  CodeAnalyzer::Checker

--- a/lib/guideline/checkers/long_line_checker.rb
+++ b/lib/guideline/checkers/long_line_checker.rb
@@ -1,5 +1,7 @@
 module Guideline
   class LongLineChecker < Checker
+    DEFAULT_MAX = 80
+
     def check(path)
       lines(path).select(&:has_error?).each do |line|
         report(
@@ -19,7 +21,7 @@ module Guideline
     end
 
     def max
-      @options[:max]
+      (@options[:max] || DEFAULT_MAX).to_i
     end
 
     class LineChecker

--- a/lib/guideline/checkers/long_method_checker.rb
+++ b/lib/guideline/checkers/long_method_checker.rb
@@ -3,6 +3,8 @@ require "ostruct"
 
 module Guideline
   class LongMethodChecker < Checker
+    DEFAULT_MAX = 10
+
     def check(path)
       MethodParser.parse(path.read) do |method|
         if method.height > max
@@ -18,7 +20,7 @@ module Guideline
     private
 
     def max
-      @options[:max] || 50
+      (@options[:max] || DEFAULT_MAX).to_i
     end
 
     class Method < OpenStruct

--- a/lib/guideline/option_parser.rb
+++ b/lib/guideline/option_parser.rb
@@ -1,0 +1,89 @@
+require "optparse"
+
+module Guideline
+  class OptionParser < ::OptionParser
+    OPTIONS = [
+      "--no-abc-complexity",      "(default: true) check method ABC complexity",
+      "--no-hard-tab-indent",     "(default: true) check hard tab indent",
+      "--no-hash-comma",          "(default: true) check last comma in Hash literal",
+      "--no-long-line",           "(default: true) check line length",
+      "--no-long-method",         "(default: true) check method height",
+      "--no-trailing-whitespace", "(default: true) check trailing whitespace",
+      "--no-unused-method",       "(default: true) check unused method",
+      "--abc-complexity=",        "(default:   15) threshold of ABC complexity",
+      "--long-line=",             "(default:   80) threshold of long line",
+      "--long-method=",           "(default:   10) threshold of long method",
+      "--path=",                  "(default:   ./) checked file or dir or glob pattern",
+    ]
+
+    def self.parse(argv = ARGV)
+      new.parse(argv)
+    end
+
+    def initialize(*)
+      super
+      configure_checker_options
+    end
+
+    def parse(*)
+      super
+      options
+    end
+
+    def options
+      @options ||= {}
+    end
+
+    private
+
+    def configure_checker_options
+      arguments.each do |argument|
+        on(argument.key, argument.description) do |value|
+          options[argument.to_sym] = value
+        end
+      end
+    end
+
+    def arguments
+      OPTIONS.each_slice(2).map do |key, description|
+        Argument.new(key, description)
+      end
+    end
+
+    class Argument
+      attr_reader :key, :description
+
+      def initialize(key, description)
+        @key         = key
+        @description = description
+      end
+
+      def to_sym
+        str = @key
+        str = without_head_hyphen(str)
+        str = without_head_no(str)
+        str = without_last_equal(str)
+        str = underscored(str)
+        str.to_sym
+      end
+
+      private
+
+      def underscored(str)
+        str.gsub("-", "_")
+      end
+
+      def without_head_hyphen(str)
+        str.gsub(/^--/, "")
+      end
+
+      def without_head_no(str)
+        str.gsub(/^no-/, "")
+      end
+
+      def without_last_equal(str)
+        str.gsub(/=$/, "")
+      end
+    end
+  end
+end

--- a/lib/guideline/path_finder.rb
+++ b/lib/guideline/path_finder.rb
@@ -1,0 +1,54 @@
+require "pathname"
+
+module Guideline
+  class PathFinder
+    def self.find(pattern)
+      new(pattern).paths
+    end
+
+    def initialize(pattern)
+      @pattern = pattern
+    end
+
+    def paths
+      Pathname.glob(recognized_pattern)
+    end
+
+    private
+
+    def pattern
+      @pattern
+    end
+
+    def path
+      @path ||= Pathname.new(pattern)
+    end
+
+    def recognized_pattern
+      case
+      when pattern_not_given?
+        default_glob
+      when directory?
+        default_glob_with_directory
+      else
+        pattern
+      end
+    end
+
+    def pattern_not_given?
+      pattern.nil?
+    end
+
+    def directory?
+      path.directory?
+    end
+
+    def default_glob
+      "**/*.rb"
+    end
+
+    def default_glob_with_directory
+      File.join(path, default_glob)
+    end
+  end
+end

--- a/lib/guideline/visitor.rb
+++ b/lib/guideline/visitor.rb
@@ -4,9 +4,9 @@ module Guideline
   class Visitor
     attr_reader :options
 
-    def initialize(options, &block)
-      @options = options
-      @block   = block
+    def initialize(pattern, checkers)
+      @pattern  = pattern
+      @checkers = checkers
     end
 
     def visit
@@ -36,59 +36,19 @@ module Guideline
     private
 
     def paths
-      PathFinder.find(options)
+      PathFinder.find(pattern)
     end
 
     def checkers
-      @checkers ||= Array(options[:checker])
+      @checkers
+    end
+
+    def pattern
+      @pattern
     end
 
     def errors
       @errors ||= checkers.select(&:has_error?).map(&:errors).inject([], &:+)
-    end
-
-    class PathFinder
-      attr_reader :options
-
-      def self.find(options = {})
-        new(options).paths
-      end
-
-      def initialize(options = {})
-        @options = options
-      end
-
-      def paths
-        (found_paths - excepted_paths).select(&:exist?)
-      end
-
-      private
-
-      def found_paths
-        Pathname.glob(only_pattern)
-      end
-
-      def excepted_paths
-        if except_pattern
-          Pathname.glob(except_pattern)
-        else
-          []
-        end
-      end
-
-      def only_pattern
-        if options[:only]
-          File.expand_path(options[:only])
-        else
-          File.expand_path("**/*.rb")
-        end
-      end
-
-      def except_pattern
-        if options[:except]
-          File.expand_path(options[:except])
-        end
-      end
     end
   end
 end

--- a/spec/guideline/option_parser_spec.rb
+++ b/spec/guideline/option_parser_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+module Guideline
+  describe OptionParser do
+    describe ".parse" do
+      subject do
+        described_class.parse(argv)
+      end
+
+      context "when ARGV is --no-abc-complexity" do
+        let(:argv) do
+          ["--no-abc-complexity"]
+        end
+        it { should == { :abc_complexity => false } }
+      end
+
+      context "when ARGV is --abc-complexity 5" do
+        let(:argv) do
+          ["--abc-complexity", "5"]
+        end
+        it { should == { :abc_complexity => "5" } }
+      end
+
+      context "when ARGV is --non-existent-key" do
+        let(:argv) do
+          ["--non-existent-key"]
+        end
+        it do
+          expect { subject }.to raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/guideline/visitor_spec.rb
+++ b/spec/guideline/visitor_spec.rb
@@ -3,11 +3,15 @@ require "spec_helper"
 module Guideline
   describe Visitor do
     let(:visitor) do
-      described_class.new(options)
+      described_class.new(pattern, checkers)
     end
 
-    let(:options) do
-      { :checker => [checker] }
+    let(:pattern) do
+      nil
+    end
+
+    let(:checkers) do
+      [checker]
     end
 
     let(:checker) do
@@ -16,29 +20,16 @@ module Guideline
 
     describe "#visit" do
       let(:path) do
-        Pathname.new("spec/guideline/visitor_spec.rb")
+        Pathname.new(__FILE__)
       end
 
-      context "when :only option is specified" do
-        before do
-          options[:only] = "lib/**/*.rb"
-        end
-
-        it "does not visit paths which are not specified" do
-          checker.should_not_receive(:check).with(path)
-          visitor.visit
-        end
+      let(:pattern) do
+        path.to_s
       end
 
-      context "when :except option is specified" do
-        before do
-          options[:except] = "spec/**/*.rb"
-        end
-
-        it "does not visit paths which are specified" do
-          checker.should_not_receive(:check).with(path)
-          visitor.visit
-        end
+      it "calls checker.check with found paths" do
+        checker.should_receive(:check).with(path).at_least(1)
+        visitor.visit
       end
     end
 


### PR DESCRIPTION
At present Guideline takes YAML for an user to custom its behavior, but this is not useful way in real usage. I'd like Guideline to take command line options.

```
$ guideline
Usage: guideline [options]
        --no-abc-complexity          (default: true) check method ABC complexity
        --no-hard-tab-indent         (default: true) check hard tab indent
        --no-hash-comma              (default: true) check last comma in Hash literal
        --no-long-line               (default: true) check line length
        --no-long-method             (default: true) check method height
        --no-trailing-whitespace     (default: true) check trailing whitespace
        --no-unused-method           (default: true) check unused method
        --abc-complexity=            (default:   15) threshold of ABC complexity
        --long-line=                 (default:   80) threshold of long line
        --long-method=               (default:   10) threshold of long method
```

This issue is related to https://github.com/r7kamura/guideline/issues/12
